### PR TITLE
Add the root directory to the PYTHONPATH of every task.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,16 +10,17 @@ releases are available on `Anaconda.org
 0.0.6 - 2020-
 -------------
 
--
+- Add project root directory to the ``PYTHONPATH`` so that every task can import with
+  ``from src.... import ...`` (:gh:`13`).
 
 
 0.0.5 - 2020-04-26
 ------------------
 
 - Added ``pydot`` as a package dependency  and added all information in ``config`` to
-  render a task template (:gh:`11`)
-- Remove references to respy (:gh:`8`)
-- Fix codecov (:gh:`7`)
+  render a task template (:gh:`11`).
+- Remove references to respy (:gh:`8`).
+- Fix codecov (:gh:`7`).
 
 
 0.0.4 - 2020-04-06

--- a/pipeline/tasks.py
+++ b/pipeline/tasks.py
@@ -34,7 +34,16 @@ def _collect_user_defined_tasks(config):
 
     tasks = {}
     for path in task_files:
-        template = jinja2.Template(path.read_text())
+        try:
+            template = jinja2.Template(path.read_text())
+        except jinja2.exceptions.TemplateSyntaxError as e:
+            message = (
+                f"\n\nAn error happened while rendering the task template {path}. "
+                "This happens because a jinja2 variable within the template is not "
+                "defined, misspelled, etc.."
+            )
+            raise Exception(message) from e
+
         rendered_template = template.render(**config)
 
         tasks_in_file = read_yaml(rendered_template)


### PR DESCRIPTION
### Current behavior

It is not possible to import from other files in the source directory.

### Solution / Implementation

The project directory is added to the `PYTHONPATH` of every task so `from src. ... import ...` is possible.